### PR TITLE
Update build.gradle to allow override of MS auth library version.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,7 @@ ext {
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.6.1'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.5'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.5.1'
+    msalVersion = project.hasProperty("msalVersion") ? rootProject.ext.msalVersion : '4.9.0'
 }
 
 buildscript {
@@ -63,7 +64,7 @@ allprojects {
 dependencies {
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
-    implementation "com.microsoft.identity.client:msal:4.9.0"
+    implementation "com.microsoft.identity.client:msal:$msalVersion"
 
     testImplementation "org.json:json:20230227"
     testImplementation "org.mockito:mockito-inline:5.2.0"


### PR DESCRIPTION
I think this is the least impact in terms of blast radius. I can also update the docs with a caveat that changing the library version may break the plugin. Let me know what you all think.